### PR TITLE
Keep vendor JS in order when copied then concatenated

### DIFF
--- a/dist/gulp/tasks/process_scripts.js
+++ b/dist/gulp/tasks/process_scripts.js
@@ -32,7 +32,8 @@
     * Copy vendors
     */
     gulp.task('_g_js_copy_vendors', function() {
-        return gulp.src(config.scripts.vendor.files)
+        return Object.keys(config.scripts.vendor.files).forEach(function(key) {
+            gulp.src(config.scripts.vendor.files[key])
             .pipe($.gulpif(argv.notify, $.plumber({
                 errorHandler: $.notify.onError(function(){
                     if (!argv.notify) {
@@ -46,8 +47,8 @@
                     }
                 })
             })))
-            .pipe($.rename(function (path) {
-                return path;
+            .pipe($.rename({
+                prefix: key
             }))
             .pipe(gulp.dest(config.scripts.vendor.dest))
             .pipe($.gulpif(argv.notify, $.notify({
@@ -55,6 +56,7 @@
                 title   : config.projectName + ' (Gulp)',
                 onLast  : true
             })));
+        });
     });
 
     /**


### PR DESCRIPTION
Prefix each js vendor file declarer with its index number.
So it keep the declared order in config.js when it is concatenated.
